### PR TITLE
Handle missing store fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Cargar datos
+
+Al iniciar la aplicación no existen tiendas cargadas. Para importarlas debes
+seleccionar un archivo `.json` usando el campo de subida de archivos. El JSON
+puede ser un array de objetos o un objeto con una propiedad `stores` o `data`
+que contenga dicho array. Cada elemento debe incluir al menos el campo `url`.
+Los campos `title` (o `name`), `address` y `categoryName` son opcionales y, si
+faltan, se mostrarán como cadenas vacías. Opcionalmente se acepta `phone`.
+
+Ejemplo:
+
+```json
+[
+  {
+    "title": "Metal Store",
+    "address": "Calle Falsa 123",
+    "phone": "555-1234",
+    "categoryName": "Ferretería",
+    "url": "https://maps.google.com/?q=Metal+Store"
+  }
+]
+```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ Ejemplo:
   }
 ]
 ```
+
+## Depuración manual
+
+Al cargar las tiendas se mostrará un botón de **Eliminar** (❌) y uno de **Aprobar** (✅) en cada tarjeta. El botón de eliminar quita la tienda de la vista sin guardar nada. El de aprobar también la oculta, pero la almacena temporalmente en memoria.
+
+Arriba de la lista encontrarás el botón **Exportar aprobadas**. Al pulsarlo se descargará un archivo `approved_stores.txt` con las tiendas aprobadas en el siguiente formato:
+
+```
+Nombre
+Dirección
+Teléfono
+Categoría
+
+(repetir por cada tienda)
+```
+
+Después de exportar, la lista de aprobadas se vacía. Estos datos sólo existen en memoria; al recargar la página se pierden.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import Card from './components/Card.jsx'
 import Input from './components/Input.jsx'
 import Button from './components/Button.jsx'
 import ScrollArea from './components/ScrollArea.jsx'
-import { Trash2 } from 'lucide-react'
 
-const STORAGE_KEY = 'metalStores'
 const REQUIRED_FIELDS = ['url']
 
 export default function App() {
   const [stores, setStores] = useState([])
   const [search, setSearch] = useState('')
   const [error, setError] = useState('')
+  const [approvedStores, setApprovedStores] = useState([])
   const fileInput = useRef(null)
-
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    if (saved) {
-      try {
-        setStores(JSON.parse(saved))
-      } catch (e) {
-        console.error(e)
-      }
-    }
-  }, [])
 
   const handleFile = (e) => {
     const file = e.target.files[0]
@@ -64,7 +52,6 @@ export default function App() {
           }
         }
         setStores(entries)
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
       } catch {
         setError('Error al leer el archivo.')
       }
@@ -72,10 +59,36 @@ export default function App() {
     reader.readAsText(file)
   }
 
-  const handleDelete = (title) => {
-    const updated = stores.filter((s) => s.title !== title)
-    setStores(updated)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+  const handleApprove = (idx) => {
+    setApprovedStores((prev) => [
+      ...prev,
+      {
+        title: stores[idx].title,
+        address: stores[idx].address,
+        phone: stores[idx].phone,
+        categoryName: stores[idx].categoryName,
+      },
+    ])
+    setStores((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  const handleExport = () => {
+    if (approvedStores.length === 0) return
+    const text = approvedStores
+      .map((s) => `${s.title}\n${s.address}\n${s.phone}\n${s.categoryName}`)
+      .join('\n\n')
+    const blob = new Blob([text], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'approved_stores.txt'
+    a.click()
+    URL.revokeObjectURL(url)
+    setApprovedStores([])
+  }
+
+  const handleDelete = (idx) => {
+    setStores((prev) => prev.filter((_, i) => i !== idx))
   }
 
   const filtered = stores.filter((s) =>
@@ -86,6 +99,13 @@ export default function App() {
     <div className="min-h-screen bg-gray-100">
       <div className="max-w-4xl mx-auto p-4 flex flex-col gap-4">
         <h1 className="text-2xl font-bold">Metal Stores</h1>
+        <Button
+          className="self-start disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={handleExport}
+          disabled={approvedStores.length === 0}
+        >
+          Exportar aprobadas
+        </Button>
         {stores.length === 0 && (
           <Input type="file" accept=".json" onChange={handleFile} ref={fileInput} />
         )}
@@ -107,12 +127,17 @@ export default function App() {
                     <span className="font-semibold">Categoría:</span> {store.categoryName}
                   </p>
                   <div className="flex gap-2 mt-2">
-                    <Button onClick={() => window.open(store.url, '_blank')}>Google Maps</Button>
+                    <Button onClick={() => window.open(store.url, '_blank')}>
+                      Google Maps
+                    </Button>
+                    <Button variant="success" onClick={() => handleApprove(idx)}>
+                      ✅
+                    </Button>
                     <Button
                       variant="destructive"
-                      onClick={() => handleDelete(store.title)}
+                      onClick={() => handleDelete(idx)}
                     >
-                      <Trash2 className="w-4 h-4" />
+                      ❌
                     </Button>
                   </div>
                 </Card>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import ScrollArea from './components/ScrollArea.jsx'
 import { Trash2 } from 'lucide-react'
 
 const STORAGE_KEY = 'metalStores'
+const REQUIRED_FIELDS = ['url']
 
 export default function App() {
   const [stores, setStores] = useState([])
@@ -27,25 +28,43 @@ export default function App() {
   const handleFile = (e) => {
     const file = e.target.files[0]
     setError('')
-    if (!file || !file.name.endsWith('.json')) {
+    if (!file || !file.name.toLowerCase().endsWith('.json')) {
       setError('Selecciona un archivo .json válido.')
       return
     }
     const reader = new FileReader()
     reader.onload = (ev) => {
       try {
-        const json = JSON.parse(ev.target.result)
-        if (
-          !Array.isArray(json) ||
-          !json.every((o) =>
-            o.title && o.address && o.phone && o.categoryName && o.url
-          )
-        ) {
-          setError('Archivo JSON inválido.')
+        const raw = JSON.parse(ev.target.result)
+        let entries = Array.isArray(raw) ? raw : raw.stores || raw.data
+        if (!Array.isArray(entries)) {
+          setError('El archivo JSON debe contener un array de objetos.')
           return
         }
-        setStores(json)
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(json))
+        entries = entries.map((obj) => {
+          const normalized = {}
+          Object.entries(obj).forEach(([k, v]) => {
+            normalized[k.trim().toLowerCase()] = v
+          })
+          const entry = {
+            title: normalized.title || normalized.name || '',
+            address: normalized.address || '',
+            phone: normalized.phone || '',
+            categoryName: normalized.categoryname || normalized.category || '',
+            url: normalized.url || '',
+          }
+          return entry
+        })
+        for (let i = 0; i < entries.length; i++) {
+          for (const field of REQUIRED_FIELDS) {
+            if (!entries[i][field]) {
+              setError(`Falta el campo "${field}" en la entrada ${i + 1}.`)
+              return
+            }
+          }
+        }
+        setStores(entries)
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
       } catch {
         setError('Error al leer el archivo.')
       }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -5,6 +5,7 @@ export default function Button({ variant = 'default', className = '', ...props }
   const variants = {
     default: 'bg-blue-600 text-white hover:bg-blue-700',
     destructive: 'bg-red-600 text-white hover:bg-red-700',
+    success: 'bg-green-600 text-white hover:bg-green-700',
   };
   return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary
- relax validation to allow missing `title`, `address` and `categoryName`
- ensure missing fields default to empty strings
- update docs with new JSON requirements

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68523dd0ea708320ab5fcfcaf76a93a9